### PR TITLE
fix: rename light-beaconchain-explorer to dora-the-explorer

### DIFF
--- a/main.star
+++ b/main.star
@@ -27,8 +27,8 @@ el_forkmon = import_module(
 beacon_metrics_gazer = import_module(
     "github.com/kurtosis-tech/eth2-package/src/beacon_metrics_gazer/beacon_metrics_gazer_launcher.star"
 )
-light_beaconchain_explorer = import_module(
-    "github.com/kurtosis-tech/eth2-package/src/light_beaconchain/light_beaconchain_launcher.star"
+dora_the_explorer = import_module(
+    "github.com/kurtosis-tech/eth2-package/src/dora_explorer/dora_explorer_launcher.star"
 )
 prometheus = import_module(
     "github.com/kurtosis-tech/eth2-package/src/prometheus/prometheus_launcher.star"
@@ -277,14 +277,14 @@ def run(plan, args={}):
     )
     plan.print("Succesfully launched beacon metrics gazer")
 
-    plan.print("Launching light-beaconchain-explorer")
-    light_beaconchain_explorer_config_template = read_file(
-        static_files.LIGHT_BEACONCHAIN_CONFIG_TEMPLATE_FILEPATH
+    plan.print("Launching dora-the-explorer")
+    dora_explorer_explorer_config_template = read_file(
+        static_files.DORA_EXPLORER_CONFIG_TEMPLATE_FILEPATH
     )
-    light_beaconchain_explorer.launch_light_beacon(
-        plan, light_beaconchain_explorer_config_template, all_cl_client_contexts
+    dora_the_explorer.launch_dora_explorer(
+        plan, dora_explorer_explorer_config_template, all_cl_client_contexts
     )
-    plan.print("Succesfully light-beaconchain-explorer")
+    plan.print("Succesfully launched dora-the-explorer")
 
     plan.print("Launching prometheus...")
     prometheus_private_url = prometheus.launch_prometheus(

--- a/src/dora_explorer/dora_explorer_launcher.star
+++ b/src/dora_explorer/dora_explorer_launcher.star
@@ -3,15 +3,15 @@ shared_utils = import_module(
 )
 
 
-SERVICE_NAME = "light-beaconchain"
+SERVICE_NAME = "dora-the-explorer"
 IMAGE_NAME = "ethpandaops/dora-the-explorer:master"
 
 HTTP_PORT_ID = "http"
 HTTP_PORT_NUMBER = 8080
 
-LIGHT_BEACONCHAIN_CONFIG_FILENAME = "light-beaconchain-config.yaml"
+DORA_EXPLORER_CONFIG_FILENAME = "dora-explorer-config.yaml"
 
-LIGHT_BEACONCHAIN_CONFIG_MOUNT_DIRPATH_ON_SERVICE = "/config"
+DORA_EXPLORER_CONFIG_MOUNT_DIRPATH_ON_SERVICE = "/config"
 
 VALIDATOR_RANGES_MOUNT_DIRPATH_ON_SERVICE = "/validator-ranges"
 VALIDATOR_RANGES_ARTIFACT_NAME = "validator-ranges"
@@ -29,7 +29,7 @@ USED_PORTS = {
 }
 
 
-def launch_light_beacon(
+def launch_dora_explorer(
     plan,
     config_template,
     cl_client_contexts,
@@ -49,11 +49,11 @@ def launch_light_beacon(
     )
     template_and_data_by_rel_dest_filepath = {}
     template_and_data_by_rel_dest_filepath[
-        LIGHT_BEACONCHAIN_CONFIG_FILENAME
+        DORA_EXPLORER_CONFIG_FILENAME
     ] = template_and_data
 
     config_files_artifact_name = plan.render_templates(
-        template_and_data_by_rel_dest_filepath, "light-beaconchain-config"
+        template_and_data_by_rel_dest_filepath, "dora-explorer-config"
     )
 
     config = get_config(config_files_artifact_name)
@@ -63,14 +63,14 @@ def launch_light_beacon(
 
 def get_config(config_files_artifact_name):
     config_file_path = shared_utils.path_join(
-        LIGHT_BEACONCHAIN_CONFIG_MOUNT_DIRPATH_ON_SERVICE,
-        LIGHT_BEACONCHAIN_CONFIG_FILENAME,
+        DORA_EXPLORER_CONFIG_MOUNT_DIRPATH_ON_SERVICE,
+        DORA_EXPLORER_CONFIG_FILENAME,
     )
     return ServiceConfig(
         image=IMAGE_NAME,
         ports=USED_PORTS,
         files={
-            LIGHT_BEACONCHAIN_CONFIG_MOUNT_DIRPATH_ON_SERVICE: config_files_artifact_name,
+            DORA_EXPLORER_CONFIG_MOUNT_DIRPATH_ON_SERVICE: config_files_artifact_name,
             VALIDATOR_RANGES_MOUNT_DIRPATH_ON_SERVICE: VALIDATOR_RANGES_ARTIFACT_NAME,
             CL_CONFIG_MOUNT_DIRPATH_ON_SERVICE: CL_CONFIG_ARTIFACT_NAME,
         },

--- a/src/static_files/static_files.star
+++ b/src/static_files/static_files.star
@@ -21,8 +21,8 @@ BEACON_METRICS_GAZER_CONFIG_TEMPLATE_FILEPATH = (
     STATIC_FILES_DIRPATH + "/beacon-metrics-gazer-config/config.yaml.tmpl"
 )
 
-LIGHT_BEACONCHAIN_CONFIG_TEMPLATE_FILEPATH = (
-    STATIC_FILES_DIRPATH + "/light-beaconchain-config/config.yaml.tmpl"
+DORA_EXPLORER_CONFIG_TEMPLATE_FILEPATH = (
+    STATIC_FILES_DIRPATH + "/dora-explorer-config/config.yaml.tmpl"
 )
 
 # Grafana config

--- a/static_files/dora-explorer-config/config.yaml.tmpl
+++ b/static_files/dora-explorer-config/config.yaml.tmpl
@@ -23,7 +23,7 @@ frontend:
   minimize: false # minimize html templates
 
   # Name of the site, displayed in the title tag
-  siteName: "Beaconchain Light"
+  siteName: "Dora the Explorer"
   siteSubtitle: "Kurtosis Testnet"
 
   # link to EL Explorer
@@ -49,14 +49,8 @@ beaconapi:
 
 # indexer keeps track of the latest epochs in memory.
 indexer:
-  # number of epochs to load on startup
-  prepopulateEpochs: 2
-
   # max number of epochs to keep in memory
   inMemoryEpochs: 3
-
-  # epoch processing delay (should be >= 2)
-  epochProcessingDelay: 2
 
   # disable synchronizing and everything that writes to the db (indexer just maintains local cache)
   disableIndexWriter: false


### PR DESCRIPTION
The lightweight beaconchain explorer was renamed to `Dora the Explorer` (or just `Dora`).
This PR renames all explorer related variables & references accordingly.