### PR TITLE
docs: Link to monorepo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ethereum Package
 ![Run of the Ethereum Network Package](run.gif)
 
-This is a [Kurtosis Package][starlark-docs] that will spin up a private Ethereum testnet over Docker or Kubernetes with multi-client support, Flashbot's `mev-boost` infrastructure for PBS-related testing/validation, and other useful network tools (transaction spammer, monitoring tools, etc). Kurtosis packages are entirely reproducible and composable, so this will work the same way over Docker or Kubernetes, in the cloud or locally on your machine.
+This is a [Kurtosis](https://github.com/kurtosis-tech/kurtosis/) package that will spin up a private Ethereum testnet over Docker or Kubernetes with multi-client support, Flashbot's `mev-boost` infrastructure for PBS-related testing/validation, and other useful network tools (transaction spammer, monitoring tools, etc). Kurtosis packages are entirely reproducible and composable, so this will work the same way over Docker or Kubernetes, in the cloud or locally on your machine.
 
 Specifically, this package will:
 1. Generate Execution Layer (EL) & Consensus Layer (CL) genesis information using [the Ethereum genesis generator](https://github.com/ethpandaops/ethereum-genesis-generator).


### PR DESCRIPTION
Right now the first link in the README is to a quite-technical page about Starlark deep in our docs. This PR changes to linking to the monorepo for a better overview of what's happening