### PR TITLE
Add configurable spamming frequency to custom flood

### DIFF
--- a/.circleci/tests/mev.json
+++ b/.circleci/tests/mev.json
@@ -1,9 +1,21 @@
 {
     "mev_type": "full",
+    "additional_services": [
+        "tx_spammer",
+        "blob_spammer",
+        "custom_flood",
+        "goomy_blob",
+        "cl_forkmon",
+        "el_forkmon",
+        "beacon_metrics_gazer",
+        "dora",
+        "full_beaconchain_explorer",
+        "prometheus_grafana"
+    ],
     "mev_params": {
-        "launch_custom_flood": true,
         "mev_relay_image": "flashbots/mev-boost-relay:0.27"
     },
+    
     "network_params": {
         "seconds_per_slot": 3,
         "capella_fork_epoch": 0

--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ To configure the package behaviour, you can modify your `network_params.json` fi
     "additional_services": [
       	"tx_spammer",
         "blob_spammer",
-        "goomy_blob"
+        "custom_flood",
+        "goomy_blob",
         "cl_forkmon",
         "el_forkmon",
         "beacon_metrics_gazer",
@@ -295,7 +296,9 @@ To configure the package behaviour, you can modify your `network_params.json` fi
       "mev_flood_seconds_per_bundle": 15,
       // A custom flood script that increases the balance of the coinbase addresss leading to more reliable
       // payload delivery
-      "launch_custom_flood": false
+      "custom_flood": {
+        "delay": 1
+    }
     }
 }
 ```

--- a/examples/capella-mev.json
+++ b/examples/capella-mev.json
@@ -20,7 +20,6 @@
 	},
 	"mev_params": {
         "mev_flood_seconds_per_bundle": 12,
-        "launch_custom_flood": false,
         "mev_flood_extra_args": [ "--txsPerBundle=300" ],
         "mev_flood_image": "flashbots/mev-flood:0.0.9",
         "mev_relay_image": "flashbots/mev-boost-relay:0.27.0"

--- a/main.star
+++ b/main.star
@@ -179,13 +179,6 @@ def run(plan, args={}):
             mev_params.mev_flood_seconds_per_bundle,
             genesis_constants.PRE_FUNDED_ACCOUNTS,
         )
-        if args_with_right_defaults.mev_params.launch_custom_flood:
-            mev_custom_flood_module.spam_in_background(
-                plan,
-                genesis_constants.PRE_FUNDED_ACCOUNTS[-1].private_key,
-                genesis_constants.PRE_FUNDED_ACCOUNTS[0].address,
-                el_uri,
-            )
         mev_endpoints.append(endpoint)
 
     # spin up the mev boost contexts if some endpoints for relays have been passed
@@ -318,6 +311,14 @@ def run(plan, args={}):
         elif additional_service == "prometheus_grafana":
             # Allow prometheus to be launched last so is able to collect metrics from other services
             launch_prometheus_grafana = True
+        elif additional_service == "custom_flood":
+            mev_custom_flood_module.spam_in_background(
+                plan,
+                genesis_constants.PRE_FUNDED_ACCOUNTS[-1].private_key,
+                genesis_constants.PRE_FUNDED_ACCOUNTS[0].address,
+                el_uri,
+                args_with_right_defaults.custom_flood,
+            )
         else:
             fail("Invalid additional service %s" % (additional_service))
     if launch_prometheus_grafana:

--- a/network_params.json
+++ b/network_params.json
@@ -49,7 +49,6 @@
 		"mev_builder_extra_args": [],
 		"mev_flood_image": "flashbots/mev-flood",
 		"mev_flood_extra_args": [],
-		"mev_flood_seconds_per_bundle": 15,
-		"launch_custom_flood": false
+		"mev_flood_seconds_per_bundle": 15
 	}
 }

--- a/src/mev_custom_flood/mev_custom_flood_launcher.star
+++ b/src/mev_custom_flood/mev_custom_flood_launcher.star
@@ -2,7 +2,7 @@ PYTHON_IMAGE = "python:3.11-alpine"
 CUSTOM_FLOOD_SREVICE_NAME = "mev-custom-flood"
 
 
-def spam_in_background(plan, sender_key, receiver_key, el_uri):
+def spam_in_background(plan, sender_key, receiver_key, el_uri, params):
     sender_script = plan.upload_files("./sender.py")
 
     plan.add_service(
@@ -21,12 +21,12 @@ def spam_in_background(plan, sender_key, receiver_key, el_uri):
 
     plan.exec(
         service_name=CUSTOM_FLOOD_SREVICE_NAME,
-        recipe=ExecRecipe(["pip", "install", "web3"]),
+        recipe=ExecRecipe(["pip", "install", "web3", "click"]),
     )
 
     plan.exec(
         service_name=CUSTOM_FLOOD_SREVICE_NAME,
         recipe=ExecRecipe(
-            ["/bin/sh", "-c", "nohup python /tmp/sender.py > /dev/null 2>&1 &"]
+            ["/bin/sh", "-c", "nohup python /tmp/sender.py  --delay {} > /dev/null 2>&1 &".format(params.delay)]
         ),
     )

--- a/src/mev_custom_flood/sender.py
+++ b/src/mev_custom_flood/sender.py
@@ -2,12 +2,15 @@
 this is s a really dumb script that sends tokens to the receiver from the sender every 3 seconds
 this is being used as of 2023-09-06 to guarantee that payloads are delivered
 """
+from functools import partial
 
 from web3 import Web3
 from web3.middleware import construct_sign_and_send_raw_middleware
 import os
 import time
 import logging
+import click
+
 
 VALUE_TO_SEND = 0x9184
 
@@ -17,48 +20,51 @@ logging.basicConfig(filename="/tmp/sender.log",
                     datefmt='%H:%M:%S',
                     level=logging.DEBUG)
 
+# this is the last prefunded address
+SENDER = os.getenv("SENDER_PRIVATE_KEY", "17fdf89989597e8bcac6cdfcc001b6241c64cece2c358ffc818b72ca70f5e1ce")
+# this is the first prefunded address
+RECEIVER = os.getenv("RECEIVER_PUBLIC_KEY", "0x878705ba3f8Bc32FCf7F4CAa1A35E72AF65CF766")
+EL_URI = os.getenv("EL_RPC_URI", 'http://0.0.0.0:53913')
 
-def flood():
-    # this is the last prefunded address
-    sender = os.getenv("SENDER_PRIVATE_KEY", "17fdf89989597e8bcac6cdfcc001b6241c64cece2c358ffc818b72ca70f5e1ce")
-    # this is the first prefunded address
-    receiver = os.getenv("RECEIVER_PUBLIC_KEY", "0x878705ba3f8Bc32FCf7F4CAa1A35E72AF65CF766")
-    el_uri = os.getenv("EL_RPC_URI", 'http://0.0.0.0:53913')
+def send_transaction():
+    # Setting w3 as constant causes recursion exceeded error after ~500 transactions
+    # Thus it's created everytime a transaction is sent
+    w3 = Web3(Web3.HTTPProvider(EL_URI))
 
-    logging.info(f"Using sender {sender} receiver {receiver} and el_uri {el_uri}")
+    sender_account = w3.eth.account.from_key(SENDER)
+    w3.middleware_onion.add(construct_sign_and_send_raw_middleware(sender_account))
 
-    w3 = Web3(Web3.HTTPProvider(el_uri))
+    transaction = {
+        "from": sender_account.address,
+        "value": VALUE_TO_SEND,
+        "to": RECEIVER,
+        "data": "0xabcd",
+        "gasPrice": w3.eth.gas_price,
+    }
 
-    sender_account = w3.eth.account.from_key(sender)
+    estimated_gas = w3.eth.estimate_gas(transaction)
 
-    while True:
-        time.sleep(3)
+    transaction["gas"] = estimated_gas
 
-        w3.middleware_onion.add(construct_sign_and_send_raw_middleware(sender_account))
+    tx_hash = w3.eth.send_transaction(transaction)
 
-        transaction = {
-            "from": sender_account.address,
-            "value": VALUE_TO_SEND,
-            "to": receiver,
-            "data": "0xabcd",
-            "gasPrice": w3.eth.gas_price,
-        }
+    tx = w3.eth.get_transaction(tx_hash)
+    logging.info(tx_hash.hex())
+    assert tx["from"] == sender_account.address
 
-        estimated_gas = w3.eth.estimate_gas(transaction)
-
-        transaction["gas"] = estimated_gas
-
-        tx_hash = w3.eth.send_transaction(transaction)
-
-        tx = w3.eth.get_transaction(tx_hash)
-        logging.info(tx_hash.hex())
-        assert tx["from"] == sender_account.address
+def delayed_send(delay):
+    send_transaction()
+    time.sleep(delay)
 
 
-def run_infinitely():
+@click.command()
+@click.option('--delay', default=0.5, help='Delay between successive transaction sends (in seconds). The value may be an integer or decimal')
+def run_infinitely(delay):
+    logging.info(f"Using sender {SENDER} receiver {RECEIVER} and el_uri {EL_URI}")
+    spam = send_transaction if delay == 0 else partial(delayed_send, delay)
     while True:
         try:
-            flood()
+            spam()
         except Exception as e:
             print("e")
             print("restarting flood as previous one failed")

--- a/src/package_io/parse_input.star
+++ b/src/package_io/parse_input.star
@@ -94,6 +94,7 @@ def parse_input(plan, input_args):
 
     result["tx_spammer_params"] = get_default_tx_spammer_params()
     result["goomy_blob_params"] = get_default_goomy_blob_params()
+    result["custom_flood"] = dict(get_default_custom_flood_params(), **result["custom_flood"])
 
     return struct(
         participants=[
@@ -162,13 +163,15 @@ def parse_input(plan, input_args):
             mev_flood_seconds_per_bundle=result["mev_params"][
                 "mev_flood_seconds_per_bundle"
             ],
-            launch_custom_flood=result["mev_params"]["launch_custom_flood"],
         ),
         tx_spammer_params=struct(
             tx_spammer_extra_args=result["tx_spammer_params"]["tx_spammer_extra_args"],
         ),
         goomy_blob_params=struct(
             goomy_blob_args=result["goomy_blob_params"]["goomy_blob_args"],
+        ),
+        custom_flood=struct(
+            delay=result["custom_flood"]["delay"],
         ),
         launch_additional_services=result["launch_additional_services"],
         additional_services=result["additional_services"],
@@ -397,8 +400,6 @@ def get_default_mev_params():
         "mev_flood_image": "flashbots/mev-flood",
         "mev_flood_extra_args": [],
         "mev_flood_seconds_per_bundle": 15,
-        # this is a simple script that increases the balance of the coinbase address at a cadence
-        "launch_custom_flood": False,
     }
 
 
@@ -409,6 +410,12 @@ def get_default_tx_spammer_params():
 def get_default_goomy_blob_params():
     return {"goomy_blob_args": []}
 
+
+def get_default_custom_flood_params():
+    # this is a simple script that increases the balance of the coinbase address at a cadence
+    return {
+        "delay": 1
+    }
 
 # TODO perhaps clean this up into a map
 def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_type):


### PR DESCRIPTION
The PR aims to make custom flood more usable and configuration more consistent:
* Add `delay` parameter to custom flood to control frequency of transactions
* Remove `launch_custom_flood` parameter
* Add custom_flood to `additional_services`