### PR TITLE
fix: missing jwt secret

### DIFF
--- a/main.star
+++ b/main.star
@@ -1,4 +1,5 @@
 parse_input = import_module("./src/package_io/parse_input.star")
+constants = import_module("./src/package_io/constants.star")
 
 participant_network = import_module("./src/participant_network.star")
 
@@ -128,12 +129,17 @@ def run(plan, args={}):
         beacon_uri = "{0}:{1}".format(
             all_cl_client_contexts[0].ip_addr, all_cl_client_contexts[0].http_port_num
         )
-        jwt_secret = all_el_client_contexts[0].jwt_secret
+        jwt_secret = plan.run_sh(
+            run="cat " + constants.JWT_AUTH_PATH + " | tr -d '\n'",
+            image="busybox",
+            files={"/data": el_cl_data_files_artifact_uuid},
+            wait=None
+        )
         endpoint = mock_mev_launcher_module.launch_mock_mev(
             plan,
             el_uri,
             beacon_uri,
-            jwt_secret,
+            jwt_secret.output,
             args_with_right_defaults.global_client_log_level,
         )
         mev_endpoints.append(endpoint)


### PR DESCRIPTION
From the latest [commit](https://github.com/kurtosis-tech/ethereum-package/commit/743ba44d82e9433e6781e4965ef80bc83e962e25) there seems to be a breaking change when running `kurtosis run github.com/kurtosis-tech/ethereum-package '{"mev_type": "mock"}'`

```
There was an error interpreting Starlark code 
Evaluation error: struct has no .jwt_secret attribute
        at [github.com/kurtosis-tech/ethereum-package/main.star:131:47]: run

Error encountered running Starlark code.
```

This PR fixes the error.