### PR TITLE
fix: wrong builder metrics flag

### DIFF
--- a/main.star
+++ b/main.star
@@ -233,14 +233,6 @@ def run(plan, args={}):
                 )
                 all_mevboost_contexts.append(mev_boost_context)
 
-        output = struct(
-            all_participants=all_participants,
-            final_genesis_timestamp=final_genesis_timestamp,
-            genesis_validators_root=genesis_validators_root,
-        )
-
-        return output
-
     launch_prometheus_grafana = False
     for additional_service in args_with_right_defaults.additional_services:
         if additional_service == "tx_spammer":

--- a/main.star
+++ b/main.star
@@ -233,6 +233,15 @@ def run(plan, args={}):
                 )
                 all_mevboost_contexts.append(mev_boost_context)
 
+    if len(args_with_right_defaults.additional_services) == 0:
+        output = struct(
+            all_participants=all_participants,
+            final_genesis_timestamp=final_genesis_timestamp,
+            genesis_validators_root=genesis_validators_root,
+        )
+
+        return output
+
     launch_prometheus_grafana = False
     for additional_service in args_with_right_defaults.additional_services:
         if additional_service == "tx_spammer":

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -518,7 +518,7 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
                     ),
                     '--miner.extradata="Illuminate Dmocratize Dstribute"',
                     "--builder.algotype=greedy",
-                    "--metrics.builder=true",
+                    "--metrics.builder",
                 ]
                 + parsed_arguments_dict["mev_params"]["mev_builder_extra_args"],
                 "el_extra_env_vars": {


### PR DESCRIPTION
Fixes:
* Change Mev boost Builder metrics flags. Using `--metrics.builder=true` cause this flag to be considered as `false` and making builder metrics to not being recorded.
* Fix early return on https://github.com/kurtosis-tech/ethereum-package/blob/main/main.star#L236-L242 causing the execution to finish before adding the additional services.