### PR TITLE
docs: update list of maintainers in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ When you're happy with your changes:
    * `parithosh` (Ethereum Foundation)
    * `barnabasbusa` (Ethereum Foundation)
    * `pk910` (Ethereum Foundation)
-   * `samcm` (EThereum Foundation)
+   * `samcm` (Ethereum Foundation)
    * `h4ck3rk3y` (Kurtosis)
    * `mieubrisse` (Kurtosis)
    * `leederek` (Kurtosis)

--- a/README.md
+++ b/README.md
@@ -548,6 +548,8 @@ When you're happy with your changes:
 1. Add one of the maintainers of the repo as a "Review Request":
    * `parithosh` (Ethereum Foundation)
    * `barnabasbusa` (Ethereum Foundation)
+   * `pk910` (Ethereum Foundation)
+   * `samcm` (EThereum Foundation)
    * `h4ck3rk3y` (Kurtosis)
    * `mieubrisse` (Kurtosis)
    * `leederek` (Kurtosis)


### PR DESCRIPTION
this PR adds pk910 and sam from the Ethereum Foundation to the list of maintainers in the package's readme.