### PR TITLE
feat: add preregistered_validator_count network param field

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ network_params:
   # This mnemonic will a) be used to create keystores for all the types of validators that we have and b) be used to generate a CL genesis.ssz that has the children
   # validator keys already preregistered as validators
   preregistered_validator_keys_mnemonic: "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
+  # The number of pre-registered validators for genesis. If 0 or not specified then the value will be calculated from the participants
+  preregistered_validator_count: 0
   # How long you want the network to wait before starting up
   genesis_delay: 120
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -42,6 +42,7 @@ network_params:
     "giant issue aisle success illegal bike spike
     question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy
     very lucky have athlete"
+  preregistered_validator_count: 0
   genesis_delay: 120
   max_churn: 8
   ejection_balance: 16000000000

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -163,6 +163,9 @@ def input_parser(plan, input_args):
             preregistered_validator_keys_mnemonic=result["network_params"][
                 "preregistered_validator_keys_mnemonic"
             ],
+            preregistered_validator_count=result["network_params"][
+                "preregistered_validator_count"
+            ],
             num_validator_keys_per_node=result["network_params"][
                 "num_validator_keys_per_node"
             ],
@@ -411,6 +414,7 @@ def default_network_params():
     # this is temporary till we get params working
     return {
         "preregistered_validator_keys_mnemonic": "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete",
+        "preregistered_validator_count": 0,
         "num_validator_keys_per_node": 64,
         "network_id": "3151908",
         "deposit_contract_address": "0x4242424242424242424242424242424242424242",

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -78,9 +78,12 @@ def launch_participant_network(
         plan, CL_GENESIS_DATA_GENERATION_TIME + num_participants * CL_NODE_STARTUP_TIME
     )
 
-    total_number_of_validator_keys = 0
-    for participant in participants:
-        total_number_of_validator_keys += participant.validator_count
+    # if preregistered validator count is 0 (default) then calculate the total number of validators from the participants
+    total_number_of_validator_keys = network_params.preregistered_validator_count
+
+    if network_params.preregistered_validator_count == 0:
+        for participant in participants:
+            total_number_of_validator_keys += participant.validator_count
 
     plan.print("Generating EL CL data")
     # we are running bellatrix genesis (deprecated) - will be removed in the future


### PR DESCRIPTION
This PR allows you to set network_params.preregistered_validator_count. If not set, or set to 0 the original behavior of calculating the total validators via summing the staked participants is applied. 