### PR TITLE
fix: increase memory for blob spammer to prevent container from getting OOM killed

### DIFF
--- a/src/blob_spammer/blob_spammer.star
+++ b/src/blob_spammer/blob_spammer.star
@@ -6,8 +6,8 @@ ENTRYPOINT_ARGS = ["/bin/sh", "-c"]
 # The min/max CPU/memory that blob-spammer can use
 MIN_CPU = 100
 MAX_CPU = 1000
-MIN_MEMORY = 20
-MAX_MEMORY = 300
+MIN_MEMORY = 256
+MAX_MEMORY = 512
 
 
 def launch_blob_spammer(


### PR DESCRIPTION
I'm constantly getting OOM on the `blob-spammer` container, as it's regularly exceeding 300mb memory usage, and it usually only survives for a few seconds.

Bumping the `MAX_MEMORY` up prevents this from happening.

Docker resource usage graph:

<img width="910" alt="image" src="https://github.com/kurtosis-tech/ethereum-package/assets/742762/a7b1f8f2-55a4-4aa1-8c3c-d60113d036a6">
