### PR TITLE
feat: Add suave-enabled geth support

### DIFF
--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -66,6 +66,7 @@ VERBOSITY_LEVELS = {
 }
 
 BUILDER_IMAGE_STR = "builder"
+SUAVE_ENABLED_GETH_IMAGE_STR = "suave"
 
 
 def launch(
@@ -292,6 +293,13 @@ def get_config(
                 cmd[index] = "--http.api=admin,engine,net,eth,web3,debug,mev,flashbots"
             if "--ws.api" in arg:
                 cmd[index] = "--ws.api=admin,engine,net,eth,web3,debug,mev,flashbots"
+
+    if SUAVE_ENABLED_GETH_IMAGE_STR in image:
+        for index, arg in enumerate(cmd):
+            if "--http.api" in arg:
+                cmd[index] = "--http.api=admin,engine,net,eth,web3,debug,suavex"
+            if "--ws.api" in arg:
+                cmd[index] = "--ws.api=admin,engine,net,eth,web3,debug,suavex"
 
     if network == constants.NETWORK_NAME.kurtosis:
         if len(existing_el_clients) > 0:


### PR DESCRIPTION
Very minor addition to enable running suave-enabled geth (a.k.a. `suave-execution-geth`) instead of the stock geths.