### PR TITLE
fix: use the cl as the default validator image if none are defined

### DIFF
--- a/.github/tests/dencun-devnet-12.yaml
+++ b/.github/tests/dencun-devnet-12.yaml
@@ -1,28 +1,16 @@
 participants:
   - el_client_type: geth
-    el_client_image: ethpandaops/geth:master
     cl_client_type: teku
-    cl_client_image: ethpandaops/teku:master
   - el_client_type: nethermind
-    el_client_image: ethpandaops/nethermind:master
     cl_client_type: prysm
-    cl_client_image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
   - el_client_type: erigon
-    el_client_image: ethpandaops/erigon:devel
     cl_client_type: nimbus
-    cl_client_image: ethpandaops/nimbus:unstable
   - el_client_type: besu
-    el_client_image: ethpandaops/besu:main
     cl_client_type: lighthouse
-    cl_client_image: ethpandaops/lighthouse:unstable
   - el_client_type: reth
-    el_client_image: ethpandaops/reth:main
     cl_client_type: lodestar
-    cl_client_image: ethpandaops/lodestar:unstable
   - el_client_type: ethereumjs
-    el_client_image: ethpandaops/ethereumjs:master
     cl_client_type: teku
-    cl_client_image: ethpandaops/teku:master
 network_params:
   network: "dencun-devnet-12"
 additional_services: []

--- a/.github/tests/dencun-genesis.yaml
+++ b/.github/tests/dencun-genesis.yaml
@@ -1,28 +1,16 @@
 participants:
   - el_client_type: geth
-    el_client_image: ethpandaops/geth:master
     cl_client_type: teku
-    cl_client_image: ethpandaops/teku:master
   - el_client_type: nethermind
-    el_client_image: ethpandaops/nethermind:master
     cl_client_type: prysm
-    cl_client_image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
   - el_client_type: erigon
-    el_client_image: ethpandaops/erigon:devel
     cl_client_type: nimbus
-    cl_client_image: ethpandaops/nimbus:unstable
   - el_client_type: besu
-    el_client_image: ethpandaops/besu:main
     cl_client_type: lighthouse
-    cl_client_image: ethpandaops/lighthouse:unstable
   - el_client_type: reth
-    el_client_image: ethpandaops/reth:main
     cl_client_type: lodestar
-    cl_client_image: ethpandaops/lodestar:unstable
   - el_client_type: ethereumjs
-    el_client_image: ethpandaops/ethereumjs:master
     cl_client_type: teku
-    cl_client_image: ethpandaops/teku:master
 network_params:
   deneb_fork_epoch: 0
 additional_services: []

--- a/.github/tests/ephemery.yaml
+++ b/.github/tests/ephemery.yaml
@@ -12,6 +12,5 @@ participants:
   - el_client_type: ethereumjs
     cl_client_type: teku
 network_params:
-network_params:
   network: "ephemery"
 additional_services: []

--- a/.github/tests/ephemery.yaml
+++ b/.github/tests/ephemery.yaml
@@ -1,28 +1,17 @@
 participants:
   - el_client_type: geth
-    el_client_image: ethpandaops/geth:master
     cl_client_type: teku
-    cl_client_image: ethpandaops/teku:master
   - el_client_type: nethermind
-    el_client_image: ethpandaops/nethermind:master
     cl_client_type: prysm
-    cl_client_image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
   - el_client_type: erigon
-    el_client_image: ethpandaops/erigon:devel
     cl_client_type: nimbus
-    cl_client_image: ethpandaops/nimbus:unstable
   - el_client_type: besu
-    el_client_image: ethpandaops/besu:main
     cl_client_type: lighthouse
-    cl_client_image: ethpandaops/lighthouse:unstable
   - el_client_type: reth
-    el_client_image: ethpandaops/reth:main
     cl_client_type: lodestar
-    cl_client_image: ethpandaops/lodestar:unstable
   - el_client_type: ethereumjs
-    el_client_image: ethpandaops/ethereumjs:master
     cl_client_type: teku
-    cl_client_image: ethpandaops/teku:master
+network_params:
 network_params:
   network: "ephemery"
 additional_services: []

--- a/.github/tests/mev.yaml
+++ b/.github/tests/mev.yaml
@@ -9,6 +9,6 @@ additional_services:
   - prometheus_grafana
 mev_params:
   launch_custom_flood: true
-  mev_relay_image: flashbots/mev-boost-relay:0.28.0a2
+  mev_relay_image: flashbots/mev-boost-relay:latest
 network_params:
   seconds_per_slot: 3

--- a/.github/tests/mix-persistence-k8s.yaml
+++ b/.github/tests/mix-persistence-k8s.yaml
@@ -6,7 +6,6 @@ participants:
     cl_client_type: prysm
   - el_client_type: erigon
     cl_client_type: nimbus
-    cl_client_image: ethpandaops/nimbus:unstable
     use_separate_validator_client: true
   - el_client_type: besu
     cl_client_type: lighthouse

--- a/.github/tests/mix-persistence.yaml
+++ b/.github/tests/mix-persistence.yaml
@@ -6,7 +6,6 @@ participants:
     cl_client_type: prysm
   - el_client_type: erigon
     cl_client_type: nimbus
-    cl_client_image: ethpandaops/nimbus:unstable
     use_separate_validator_client: true
   - el_client_type: besu
     cl_client_type: lighthouse

--- a/.github/tests/mix-with-tools-mev.yaml
+++ b/.github/tests/mix-with-tools-mev.yaml
@@ -26,5 +26,5 @@ ethereum_metrics_exporter_enabled: true
 snooper_enabled: true
 mev_type: full
 mev_params:
-  mev_relay_image: flashbots/mev-boost-relay:0.27
+  mev_relay_image: flashbots/mev-boost-relay:latest
 persistent: True

--- a/.github/tests/sepolia-mix.yaml
+++ b/.github/tests/sepolia-mix.yaml
@@ -12,5 +12,5 @@ participants:
   - el_client_type: ethereumjs
     cl_client_type: nimbus
 network_params:
-  network: "sepolia"
+  network: sepolia
 additional_services: []

--- a/.github/tests/split-nimbus.yaml
+++ b/.github/tests/split-nimbus.yaml
@@ -1,27 +1,21 @@
 participants:
   - el_client_type: geth
     cl_client_type: nimbus
-    cl_client_image: ethpandaops/nimbus:unstable
     use_separate_validator_client: true
     validator_count: 0
   - el_client_type: nethermind
     cl_client_type: nimbus
     use_separate_validator_client: true
-    cl_client_image: ethpandaops/nimbus:unstable
   - el_client_type: erigon
     cl_client_type: nimbus
     use_separate_validator_client: true
-    cl_client_image: ethpandaops/nimbus:unstable
   - el_client_type: besu
     cl_client_type: nimbus
     use_separate_validator_client: true
-    cl_client_image: ethpandaops/nimbus:unstable
   - el_client_type: reth
     cl_client_type: nimbus
     use_separate_validator_client: true
-    cl_client_image: ethpandaops/nimbus:unstable
   - el_client_type: ethereumjs
     cl_client_type: nimbus
     use_separate_validator_client: true
-    cl_client_image: ethpandaops/nimbus:unstable
 additional_services: []

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -392,7 +392,18 @@ def parse_network_params(input_args):
 
         validator_client_image = participant["validator_client_image"]
         if validator_client_image == "":
-            default_image = DEFAULT_VC_IMAGES.get(validator_client_type, "")
+            if cl_image == "":
+                # If the validator client image is also empty, default to the image for the chosen CL client
+                default_image = DEFAULT_VC_IMAGES.get(validator_client_type, "")
+            else:
+                if cl_client_type == "prysm":
+                    default_image = cl_image.replace("beacon-chain", "validator")
+                elif cl_client_type == "nimbus":
+                    default_image = cl_image.replace(
+                        "nimbus-eth2", "nimbus-validator-client"
+                    )
+                else:
+                    default_image = cl_image
             if default_image == "":
                 fail(
                     "{0} received an empty image name and we don't have a default for it".format(

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -775,8 +775,8 @@ def launch_participant_network(
             launcher=validator_client.new_validator_client_launcher(
                 el_cl_genesis_data=el_cl_data
             ),
-            service_name="validator-client-{0}-{1}".format(
-                index_str, validator_client_type
+            service_name="val-{0}-{1}-{2}".format(
+                index_str, validator_client_type, el_client_type
             ),
             validator_client_type=validator_client_type,
             image=participant.validator_client_image,

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -775,7 +775,7 @@ def launch_participant_network(
             launcher=validator_client.new_validator_client_launcher(
                 el_cl_genesis_data=el_cl_data
             ),
-            service_name="val-{0}-{1}-{2}".format(
+            service_name="vc-{0}-{1}-{2}".format(
                 index_str, validator_client_type, el_client_type
             ),
             validator_client_type=validator_client_type,


### PR DESCRIPTION
This PR ensures that the validator image will be the same as CL image (if one is defined) and only fallback to the default validator image if there is no validator image nor beacon image is defined. 