### PR TITLE
fix: fix end index in validator ranges file

### DIFF
--- a/src/prelaunch_data_generator/validator_keystores/validator_ranges_generator.star
+++ b/src/prelaunch_data_generator/validator_keystores/validator_ranges_generator.star
@@ -16,7 +16,7 @@ def generate_validator_ranges(
             continue
         start_index = running_total_validator_count
         running_total_validator_count += participant.validator_count
-        end_index = start_index + participant.validator_count
+        end_index = start_index + participant.validator_count - 1
         service_name = client.beacon_service_name
         data.append(
             {


### PR DESCRIPTION
The ranges.yaml currently looks like this:
```
0-250: cl-1-lighthouse-geth
250-500: cl-2-prysm-reth
500-750: cl-3-lodestar-besu
```

but the end index should be inclusive:
```
0-249: cl-1-lighthouse-geth
250-499: cl-2-prysm-reth
500-749: cl-3-lodestar-besu
```