### PR TITLE
fix: use new validator names in assertoor config

### DIFF
--- a/src/assertoor/assertoor_launcher.star
+++ b/src/assertoor/assertoor_launcher.star
@@ -67,7 +67,7 @@ def launch_assertoor(
                     cl_client.http_port_num,
                     el_client.ip_addr,
                     el_client.rpc_port_num,
-                    cl_client.beacon_service_name,
+                    full_name,
                 )
             )
 


### PR DESCRIPTION
assertoor config still had a few names in old format, this replaces them with the new format