### PR TITLE
fix: use correct dora & assertoor images

### DIFF
--- a/src/assertoor/assertoor_launcher.star
+++ b/src/assertoor/assertoor_launcher.star
@@ -116,8 +116,6 @@ def get_config(
 
     if assertoor_params.image != "":
         IMAGE_NAME = assertoor_params.image
-    elif network_params.electra_fork_epoch != None:
-        IMAGE_NAME = "ethpandaops/assertoor:verkle-support"
     else:
         IMAGE_NAME = "ethpandaops/assertoor:latest"
 

--- a/src/dora/dora_launcher.star
+++ b/src/dora/dora_launcher.star
@@ -87,11 +87,7 @@ def get_config(
         DORA_CONFIG_FILENAME,
     )
 
-    # TODO: This is a hack to get the verkle support image for the electra fork
-    if electra_fork_epoch != None or "verkle" in network:
-        IMAGE_NAME = "ethpandaops/dora:verkle-support"
-    else:
-        IMAGE_NAME = "ethpandaops/dora:master"
+    IMAGE_NAME = "ethpandaops/dora:latest"
 
     return ServiceConfig(
         image=IMAGE_NAME,


### PR DESCRIPTION
Verkle support has been dropped from the package.
Dora & Assertoor were using custom images to support verkle,  these images are now accidentally used, as electra_fork_epoch is set to 500 now by default.