### PR TITLE
fix: fix failing persistence test

### DIFF
--- a/.github/tests/mix-persistence.yaml
+++ b/.github/tests/mix-persistence.yaml
@@ -1,6 +1,4 @@
 participants:
-  - el_type: besu
-    cl_type: lighthouse
   - el_type: geth
     cl_type: teku
     use_separate_vc: true
@@ -11,6 +9,8 @@ participants:
     use_separate_vc: true
   - el_type: reth
     cl_type: lodestar
+  - el_type: besu
+    cl_type: lighthouse
   - el_type: ethereumjs
     cl_type: nimbus
 additional_services: []


### PR DESCRIPTION
fixed the failing persistence test by re-ordering the clients list.

The test fails because initialization of all EL clients takes longer than the initial genesis delay.
Due to this, lighhouse returns an unhealty result for its health check as it's post-genesis and not following a chain / has no peers.
The kurtosis package waits for a healthy result, which never occurs as all other BNs & VCs are missing at that point.

The fix proposed in this PR is a workaround as it moves the lighthouse node further down to ensure it can connect to other nodes initialized before.

There is an alternative approach to fix this issue:
```
network_params:
  genesis_delay: 300
```
which ensures all clients are properly initialized before the network starts.