### PR TITLE
fix: add --contract-deployment-block parameter for Prysm

### DIFF
--- a/src/cl/prysm/prysm_launcher.star
+++ b/src/cl/prysm/prysm_launcher.star
@@ -271,6 +271,7 @@ def get_beacon_config(
             + constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER
             + "/genesis.ssz",
         )
+        cmd.append("--contract-deployment-block=0")
         if (
             network == constants.NETWORK_NAME.kurtosis
             or constants.NETWORK_NAME.shadowfork in network


### PR DESCRIPTION
This parameter is important. Prism will handle deposit logs from `--contract-deployment-block` to the latest block. If this parameter is missed, Prysm's proposed block's eth1 data will have no deposit data.

The default value is 11184524, which is used for the mainnet.

https://github.com/ethpandaops/dencun-devnets/blob/master/ansible/inventories/devnet-12/group_vars/prysm.yaml#L52C5-L52C33