### PR TITLE
feat: add snooper urls to assertoor config

### DIFF
--- a/src/assertoor/assertoor_launcher.star
+++ b/src/assertoor/assertoor_launcher.star
@@ -169,7 +169,14 @@ def new_config_template_data(listen_port_num, client_info, vc_info, assertoor_pa
     }
 
 
-def new_client_info(beacon_http_url, el_ip_addr, el_port_num, el_snooper_context, cl_snooper_context, full_name):
+def new_client_info(
+    beacon_http_url,
+    el_ip_addr,
+    el_port_num,
+    el_snooper_context,
+    cl_snooper_context,
+    full_name,
+):
     snooper_enabled = False
     el_snooper_url = ""
     cl_snooper_url = ""

--- a/src/assertoor/assertoor_launcher.star
+++ b/src/assertoor/assertoor_launcher.star
@@ -50,11 +50,14 @@ def launch_assertoor(
         ) = shared_utils.get_client_names(
             participant, index, participant_contexts, participant_configs
         )
+
         all_client_info.append(
             new_client_info(
                 cl_client.beacon_http_url,
                 el_client.ip_addr,
                 el_client.rpc_port_num,
+                participant.snooper_engine_context,
+                participant.snooper_beacon_context,
                 full_name,
             )
         )
@@ -65,6 +68,8 @@ def launch_assertoor(
                     cl_client.beacon_http_url,
                     el_client.ip_addr,
                     el_client.rpc_port_num,
+                    participant.snooper_engine_context,
+                    participant.snooper_beacon_context,
                     full_name,
                 )
             )
@@ -164,10 +169,28 @@ def new_config_template_data(listen_port_num, client_info, vc_info, assertoor_pa
     }
 
 
-def new_client_info(beacon_http_url, el_ip_addr, el_port_num, full_name):
+def new_client_info(beacon_http_url, el_ip_addr, el_port_num, el_snooper_context, cl_snooper_context, full_name):
+    snooper_enabled = False
+    el_snooper_url = ""
+    cl_snooper_url = ""
+
+    if el_snooper_context != None and cl_snooper_context != None:
+        snooper_enabled = True
+        el_snooper_url = "http://{0}:{1}".format(
+            el_snooper_context.ip_addr,
+            el_snooper_context.engine_rpc_port_num,
+        )
+        cl_snooper_url = "http://{0}:{1}".format(
+            cl_snooper_context.ip_addr,
+            cl_snooper_context.beacon_rpc_port_num,
+        )
+
     return {
         "CL_HTTP_URL": beacon_http_url,
         "ELIPAddr": el_ip_addr,
         "ELPortNum": el_port_num,
+        "SnooperEnabled": snooper_enabled,
+        "ELSnooperUrl": el_snooper_url,
+        "CLSnooperUrl": cl_snooper_url,
         "Name": full_name,
     }

--- a/src/assertoor/assertoor_launcher.star
+++ b/src/assertoor/assertoor_launcher.star
@@ -72,7 +72,12 @@ def launch_assertoor(
             clients_with_cl_snooper.append(client_info)
 
     template_data = new_config_template_data(
-        HTTP_PORT_NUMBER, all_client_info, clients_with_validators, clients_with_el_snooper, clients_with_cl_snooper, assertoor_params
+        HTTP_PORT_NUMBER,
+        all_client_info,
+        clients_with_validators,
+        clients_with_el_snooper,
+        clients_with_cl_snooper,
+        assertoor_params,
     )
 
     template_and_data = shared_utils.new_template_and_data(
@@ -138,7 +143,14 @@ def get_config(
     )
 
 
-def new_config_template_data(listen_port_num, all_client_info, clients_with_validators, clients_with_el_snooper, clients_with_cl_snooper, assertoor_params):
+def new_config_template_data(
+    listen_port_num,
+    all_client_info,
+    clients_with_validators,
+    clients_with_el_snooper,
+    clients_with_cl_snooper,
+    assertoor_params,
+):
     additional_tests = []
     for index, testcfg in enumerate(assertoor_params.tests):
         if type(testcfg) == "dict":

--- a/src/assertoor/assertoor_launcher.star
+++ b/src/assertoor/assertoor_launcher.star
@@ -39,7 +39,9 @@ def launch_assertoor(
     global_node_selectors,
 ):
     all_client_info = []
-    vc_info = []
+    clients_with_validators = []
+    clients_with_el_snooper = []
+    clients_with_cl_snooper = []
 
     for index, participant in enumerate(participant_contexts):
         (
@@ -51,31 +53,26 @@ def launch_assertoor(
             participant, index, participant_contexts, participant_configs
         )
 
-        all_client_info.append(
-            new_client_info(
-                cl_client.beacon_http_url,
-                el_client.ip_addr,
-                el_client.rpc_port_num,
-                participant.snooper_engine_context,
-                participant.snooper_beacon_context,
-                full_name,
-            )
+        client_info = new_client_info(
+            cl_client.beacon_http_url,
+            el_client.ip_addr,
+            el_client.rpc_port_num,
+            participant.snooper_engine_context,
+            participant.snooper_beacon_context,
+            full_name,
         )
 
+        all_client_info.append(client_info)
+
         if participant_config.validator_count != 0:
-            vc_info.append(
-                new_client_info(
-                    cl_client.beacon_http_url,
-                    el_client.ip_addr,
-                    el_client.rpc_port_num,
-                    participant.snooper_engine_context,
-                    participant.snooper_beacon_context,
-                    full_name,
-                )
-            )
+            clients_with_validators.append(client_info)
+        if participant.snooper_engine_context != None:
+            clients_with_el_snooper.append(client_info)
+        if participant.snooper_beacon_context != None:
+            clients_with_cl_snooper.append(client_info)
 
     template_data = new_config_template_data(
-        HTTP_PORT_NUMBER, all_client_info, vc_info, assertoor_params
+        HTTP_PORT_NUMBER, all_client_info, clients_with_validators, clients_with_el_snooper, clients_with_cl_snooper, assertoor_params
     )
 
     template_and_data = shared_utils.new_template_and_data(
@@ -141,7 +138,7 @@ def get_config(
     )
 
 
-def new_config_template_data(listen_port_num, client_info, vc_info, assertoor_params):
+def new_config_template_data(listen_port_num, all_client_info, clients_with_validators, clients_with_el_snooper, clients_with_cl_snooper, assertoor_params):
     additional_tests = []
     for index, testcfg in enumerate(assertoor_params.tests):
         if type(testcfg) == "dict":
@@ -157,8 +154,10 @@ def new_config_template_data(listen_port_num, client_info, vc_info, assertoor_pa
 
     return {
         "ListenPortNum": listen_port_num,
-        "ClientInfo": client_info,
-        "ValidatorClientInfo": vc_info,
+        "ClientInfo": all_client_info,
+        "ValidatorClientInfo": clients_with_validators,
+        "ElSnooperClientInfo": clients_with_el_snooper,
+        "ClSnooperClientInfo": clients_with_cl_snooper,
         "RunStabilityCheck": assertoor_params.run_stability_check,
         "RunBlockProposalCheck": assertoor_params.run_block_proposal_check,
         "RunLifecycleTest": assertoor_params.run_lifecycle_test,

--- a/src/assertoor/assertoor_launcher.star
+++ b/src/assertoor/assertoor_launcher.star
@@ -177,16 +177,19 @@ def new_client_info(
     cl_snooper_context,
     full_name,
 ):
-    snooper_enabled = False
+    el_snooper_enabled = False
     el_snooper_url = ""
+    cl_snooper_enabled = False
     cl_snooper_url = ""
 
-    if el_snooper_context != None and cl_snooper_context != None:
-        snooper_enabled = True
+    if el_snooper_context != None:
+        el_snooper_enabled = True
         el_snooper_url = "http://{0}:{1}".format(
             el_snooper_context.ip_addr,
             el_snooper_context.engine_rpc_port_num,
         )
+    if cl_snooper_context != None:
+        cl_snooper_enabled = True
         cl_snooper_url = "http://{0}:{1}".format(
             cl_snooper_context.ip_addr,
             cl_snooper_context.beacon_rpc_port_num,
@@ -196,8 +199,9 @@ def new_client_info(
         "CL_HTTP_URL": beacon_http_url,
         "ELIPAddr": el_ip_addr,
         "ELPortNum": el_port_num,
-        "SnooperEnabled": snooper_enabled,
+        "ELSnooperEnabled": el_snooper_enabled,
         "ELSnooperUrl": el_snooper_url,
+        "CLSnooperEnabled": cl_snooper_enabled,
         "CLSnooperUrl": cl_snooper_url,
         "Name": full_name,
     }

--- a/src/participant.star
+++ b/src/participant.star
@@ -6,6 +6,7 @@ def new_participant(
     cl_context,
     vc_context,
     snooper_engine_context,
+    snooper_beacon_context,
     ethereum_metrics_exporter_context,
     xatu_sentry_context,
 ):
@@ -17,6 +18,7 @@ def new_participant(
         cl_context=cl_context,
         vc_context=vc_context,
         snooper_engine_context=snooper_engine_context,
+        snooper_beacon_context=snooper_beacon_context,
         ethereum_metrics_exporter_context=ethereum_metrics_exporter_context,
         xatu_sentry_context=xatu_sentry_context,
     )

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -347,6 +347,7 @@ def launch_participant_network(
         cl_type = participant.cl_type
         vc_type = participant.vc_type
         snooper_engine_context = None
+        snooper_beacon_context = None
 
         el_context = all_el_contexts[index]
         cl_context = all_cl_contexts[index]
@@ -354,6 +355,7 @@ def launch_participant_network(
 
         if participant.snooper_enabled:
             snooper_engine_context = all_snooper_engine_contexts[index]
+            snooper_beacon_context = all_snooper_beacon_contexts[index]
 
         ethereum_metrics_exporter_context = None
 
@@ -374,6 +376,7 @@ def launch_participant_network(
             cl_context,
             vc_context,
             snooper_engine_context,
+            snooper_beacon_context,
             ethereum_metrics_exporter_context,
             xatu_sentry_context,
         )

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -261,6 +261,7 @@ def launch_participant_network(
             # This should only be the case for the MEV participant,
             # the regular participants default to False/True
             all_vc_contexts.append(None)
+            all_snooper_beacon_contexts.append(None)
             continue
 
         if cl_type in _cls_that_need_separate_vc and not participant.use_separate_vc:
@@ -268,6 +269,7 @@ def launch_participant_network(
 
         if not participant.use_separate_vc:
             all_vc_contexts.append(None)
+            all_snooper_beacon_contexts.append(None)
             continue
 
         plan.print(

--- a/static_files/assertoor-config/config.yaml.tmpl
+++ b/static_files/assertoor-config/config.yaml.tmpl
@@ -4,6 +4,10 @@ endpoints:
 - name: "{{ $client.Name }}"
   consensusUrl: "{{ $client.CL_HTTP_URL }}"
   executionUrl: "http://{{ $client.ELIPAddr }}:{{ $client.ELPortNum }}"
+  {{- if .SnooperEnabled }}
+  executionSnooperUrl: "{{ $client.ELSnooperUrl }}"
+  consensusSnooperUrl: "{{ $client.CLSnooperUrl }}"
+  {{- end }}
 {{- end }}
 
 web:

--- a/static_files/assertoor-config/config.yaml.tmpl
+++ b/static_files/assertoor-config/config.yaml.tmpl
@@ -29,33 +29,41 @@ validatorNames:
 globalVars:
   walletPrivkey: "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c"
   clientPairNames:
-{{ range $client := .ClientInfo }}
+{{- range $client := .ClientInfo }}
   - "{{ $client.Name }}"
 {{- end }}
-  validatorPairNames:
-{{ range $client := .ValidatorClientInfo }}
+  validatorPairNames: {{ if eq (len .ValidatorClientInfo) 0 }}[]{{ end }}
+{{- range $client := .ValidatorClientInfo }}
+  - "{{ $client.Name }}"
+{{- end }}
+  elSnooperClientPairNames: {{ if eq (len .ElSnooperClientInfo) 0 }}[]{{ end }}
+{{- range $client := .ElSnooperClientInfo }}
+  - "{{ $client.Name }}"
+{{- end }}
+  clSnooperClientPairNames: {{ if eq (len .ClSnooperClientInfo) 0 }}[]{{ end }}
+{{- range $client := .ClSnooperClientInfo }}
   - "{{ $client.Name }}"
 {{- end }}
 
 externalTests:
-{{ if .RunStabilityCheck }}
+{{- if .RunStabilityCheck }}
 - file: /tests/stability-check.yaml
-{{ end }}
-{{ if .RunBlockProposalCheck }}
+{{- end }}
+{{- if .RunBlockProposalCheck }}
 - file: /tests/block-proposal-check.yaml
-{{ end }}
-{{ if .RunTransactionTest }}
+{{- end }}
+{{- if .RunTransactionTest }}
 - file: /tests/eoa-transactions-test.yaml
-{{ end }}
-{{ if .RunBlobTransactionTest }}
+{{- end }}
+{{- if .RunBlobTransactionTest }}
 - file: /tests/blob-transactions-test.yaml
-{{ end }}
-{{ if .RunOpcodesTransactionTest }}
+{{- end }}
+{{- if .RunOpcodesTransactionTest }}
 - file: /tests/all-opcodes-transaction-test.yaml
-{{ end }}
-{{ if .RunLifecycleTest }}
+{{- end }}
+{{- if .RunLifecycleTest }}
 - file: /tests/validator-lifecycle-test.yaml
-{{ end }}
-{{ range $test := .AdditionalTests }}
+{{- end }}
+{{- range $test := .AdditionalTests }}
 - {{ $test }}
 {{- end }}

--- a/static_files/assertoor-config/config.yaml.tmpl
+++ b/static_files/assertoor-config/config.yaml.tmpl
@@ -4,8 +4,10 @@ endpoints:
 - name: "{{ $client.Name }}"
   consensusUrl: "{{ $client.CL_HTTP_URL }}"
   executionUrl: "http://{{ $client.ELIPAddr }}:{{ $client.ELPortNum }}"
-  {{- if .SnooperEnabled }}
+  {{- if .ELSnooperEnabled }}
   executionSnooperUrl: "{{ $client.ELSnooperUrl }}"
+  {{- end }}
+  {{- if .CLSnooperEnabled }}
   consensusSnooperUrl: "{{ $client.CLSnooperUrl }}"
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Add URL to RPC snoopers to assertoor config when snoopers are enabled.
This will allow assertoor to use the special snooper control api for further tests