### PR TITLE
fix: remove erigon's --chain parameter

### DIFF
--- a/src/el/erigon/erigon_launcher.star
+++ b/src/el/erigon/erigon_launcher.star
@@ -188,9 +188,6 @@ def get_config(
 
     cmd = [
         "erigon",
-        "--chain={0}".format(
-            network if network in constants.PUBLIC_NETWORKS else "dev"
-        ),
         "{0}".format(
             "--override.cancun=" + str(cancun_time)
             if constants.NETWORK_NAME.shadowfork in network


### PR DESCRIPTION
Erigon will disable discovery when --chain=dev: https://github.com/ledgerwatch/erigon/blob/3323fdc3489d845e9db607ad5ccc2190421b699d/cmd/utils/flags.go#L1322-L1331   
So with the current Kurtosis startup parameter, Erigon will not connect to other EL nodes.
Therefore, I propose deleting this --chain parameter in the Starlark script. If users want, they can pass the parameter through the "el_extra_params" configuration.

