### PR TITLE
fix: non-existent field access on error message

### DIFF
--- a/src/cl/cl_launcher.star
+++ b/src/cl/cl_launcher.star
@@ -105,7 +105,7 @@ def launch(
         if cl_type not in cl_launchers:
             fail(
                 "Unsupported launcher '{0}', need one of '{1}'".format(
-                    cl_type, ",".join([cl.name for cl in cl_launchers.keys()])
+                    cl_type, ",".join(cl_launchers.keys())
                 )
             )
 


### PR DESCRIPTION
Fixes #576

Now it correctly results in the error message:

```
There was an error interpreting Starlark code 
Evaluation error: fail: Unsupported launcher 'foo', need one of 'lighthouse,lodestar,nimbus,prysm,teku,grandine'
        at [github.com/kurtosis-tech/ethereum-package/main.star:104:55]: run
        at [github.com/kurtosis-tech/ethereum-package/src/participant_network.star:166:34]: launch_participant_network
        at [github.com/kurtosis-tech/ethereum-package/src/cl/cl_launcher.star:106:17]: launch
        at [0:0]: fail

Error encountered running Starlark code.
```