### PR TITLE
feat: add execution client urls to dora config

### DIFF
--- a/src/dora/dora_launcher.star
+++ b/src/dora/dora_launcher.star
@@ -131,6 +131,7 @@ def new_cl_client_info(beacon_http_url, full_name):
         "FullName": full_name,
     }
 
+
 def new_el_client_info(execution_http_url, full_name):
     return {
         "Execution_HTTP_URL": execution_http_url,

--- a/src/dora/dora_launcher.star
+++ b/src/dora/dora_launcher.star
@@ -37,8 +37,9 @@ def launch_dora(
     global_node_selectors,
 ):
     all_cl_client_info = []
+    all_el_client_info = []
     for index, participant in enumerate(participant_contexts):
-        full_name, cl_client, _, _ = shared_utils.get_client_names(
+        full_name, cl_client, el_client, _ = shared_utils.get_client_names(
             participant, index, participant_contexts, participant_configs
         )
         all_cl_client_info.append(
@@ -47,9 +48,18 @@ def launch_dora(
                 full_name,
             )
         )
+        all_el_client_info.append(
+            new_el_client_info(
+                "http://{0}:{1}".format(
+                    el_client.ip_addr,
+                    el_client.rpc_port_num,
+                ),
+                full_name,
+            )
+        )
 
     template_data = new_config_template_data(
-        network_params.network, HTTP_PORT_NUMBER, all_cl_client_info
+        network_params.network, HTTP_PORT_NUMBER, all_cl_client_info, all_el_client_info
     )
 
     template_and_data = shared_utils.new_template_and_data(
@@ -105,11 +115,12 @@ def get_config(
     )
 
 
-def new_config_template_data(network, listen_port_num, cl_client_info):
+def new_config_template_data(network, listen_port_num, cl_client_info, el_client_info):
     return {
         "Network": network,
         "ListenPortNum": listen_port_num,
         "CLClientInfo": cl_client_info,
+        "ELClientInfo": el_client_info,
         "PublicNetwork": True if network in constants.PUBLIC_NETWORKS else False,
     }
 
@@ -117,5 +128,11 @@ def new_config_template_data(network, listen_port_num, cl_client_info):
 def new_cl_client_info(beacon_http_url, full_name):
     return {
         "Beacon_HTTP_URL": beacon_http_url,
+        "FullName": full_name,
+    }
+
+def new_el_client_info(execution_http_url, full_name):
+    return {
+        "Execution_HTTP_URL": execution_http_url,
         "FullName": full_name,
     }

--- a/static_files/dora-config/config.yaml.tmpl
+++ b/static_files/dora-config/config.yaml.tmpl
@@ -45,6 +45,15 @@ beaconapi:
   redisCacheAddr: ""
   redisCachePrefix: ""
 
+executionapi:
+  endpoints:
+{{ range $clClient := .ELClientInfo }}
+    - url: "{{ $clClient.Execution_HTTP_URL }}"
+      name: "{{ $clClient.FullName }}"
+      archive: true
+{{- end }}
+  depositLogBatchSize: 1000
+
 # indexer keeps track of the latest epochs in memory.
 indexer:
   # max number of epochs to keep in memory


### PR DESCRIPTION
upcoming version of dora uses execution layer clients to crawl the deposit contract log.
This PR adds the execution client urls to the dora config.