### PR TITLE
feat: use `peer-das` image for dora when eip7594 is active

### DIFF
--- a/src/dora/dora_launcher.star
+++ b/src/dora/dora_launcher.star
@@ -95,6 +95,8 @@ def get_config(
 
     if network_params.preset == "minimal":
         IMAGE_NAME = "ethpandaops/dora:minimal-preset"
+    elif network_params.eip7594_fork_epoch != None:
+        IMAGE_NAME = "ethpandaops/dora:peer-das"
     else:
         IMAGE_NAME = "ethpandaops/dora:latest"
 


### PR DESCRIPTION
Adds PeerDAS (EIP7594) support for dory by using a [custom image](https://github.com/ethpandaops/dora/pull/61)