### PR TITLE
chore: fix ci for test runs

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: "tests-${{ github.ref }}"
+  group: "tests-${{ github.head_ref }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
previously we were using github.ref which would be main for two different PRs making the concurrency group in valid

head_ref should work for on pull request events and that should be the source branch