### PR TITLE
feat(apache): Serve all config files

### DIFF
--- a/src/apache/apache_launcher.star
+++ b/src/apache/apache_launcher.star
@@ -121,6 +121,8 @@ def get_config(
         "/network-configs/boot/" + APACHE_ENR_LIST_FILENAME,
         "/network-configs/" + APACHE_ENR_LIST_FILENAME,
         "&&",
+        "cp -R /network-configs /usr/local/apache2/htdocs/",
+        "&&",
         "tar",
         "-czvf",
         "/usr/local/apache2/htdocs/network-config.tar",


### PR DESCRIPTION
Serves all network config files via apache under the `/network-configs/ path.

```
/network-configs/besu.json
/network-configs/boot/
/network-configs/boot_enr.txt
/network-configs/boot_enr.yaml
/network-configs/bootnode.txt
/network-configs/bootstrap_nodes.txt
/network-configs/chainspec.json
/network-configs/config.yaml
/network-configs/deploy_block.txt
/network-configs/deposit_contract.txt
/network-configs/deposit_contract_block.txt
/network-configs/deposit_contract_block_hash.txt
/network-configs/genesis.json
/network-configs/genesis.ssz
/network-configs/genesis_validators_root.txt
/network-configs/mnemonics.yaml
/network-configs/parsedBeaconState.json
/network-configs/tranches/
```