### PR TITLE
fix: registration flags when using beacon node only

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -938,6 +938,9 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
             participant["cl_extra_params"].append(
                 "--builder-endpoint={0}".format(mev_url)
             )
+            participant["cl_extra_params"].append(
+                "--validators-builder-registration-default-enabled=true"
+            )
         if participant["cl_type"] == "prysm":
             participant["vc_extra_params"].append("--enable-builder")
             participant["cl_extra_params"].append(


### PR DESCRIPTION
The flag `--validators-builder-registration-default-enabled` must be used when VC/BN are combined. Otherwise validators won't be registered.
