### PR TITLE
feat: allow setting custom dora image & env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,12 @@ additional_services:
   - blutgang
   - apache
 
+# Configuration place for dora the explorer - https:#github.com/ethpandaops/dora
+dora_params:
+  # Dora docker image to use
+  # Leave blank to use the default image according to your network params
+  image: ""
+
 # Configuration place for transaction spammer - https:#github.com/MariusVanDerWijden/tx-fuzz
 tx_spammer_params:
   # A list of optional extra params that will be passed to the TX Spammer container for modifying its behaviour

--- a/README.md
+++ b/README.md
@@ -571,6 +571,9 @@ dora_params:
   # Leave blank to use the default image according to your network params
   image: ""
 
+  # A list of optional extra env_vars the dora container should spin up with
+  env: {}
+
 # Configuration place for transaction spammer - https:#github.com/MariusVanDerWijden/tx-fuzz
 tx_spammer_params:
   # A list of optional extra params that will be passed to the TX Spammer container for modifying its behaviour

--- a/main.star
+++ b/main.star
@@ -439,6 +439,7 @@ def run(plan, args={}):
         elif additional_service == "dora":
             plan.print("Launching dora")
             dora_config_template = read_file(static_files.DORA_CONFIG_TEMPLATE_FILEPATH)
+            dora_params = args_with_right_defaults.dora_params
             dora.launch_dora(
                 plan,
                 dora_config_template,
@@ -446,6 +447,7 @@ def run(plan, args={}):
                 args_with_right_defaults.participants,
                 el_cl_data_files_artifact_uuid,
                 network_params,
+                dora_params,
                 global_node_selectors,
             )
             plan.print("Successfully launched dora")

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -83,6 +83,8 @@ additional_services:
   - beacon_metrics_gazer
   - dora
   - prometheus_grafana
+dora_params:
+  image: ""
 tx_spammer_params:
   tx_spammer_extra_args: []
 goomy_blob_params:

--- a/src/dora/dora_launcher.star
+++ b/src/dora/dora_launcher.star
@@ -34,6 +34,7 @@ def launch_dora(
     participant_configs,
     el_cl_data_files_artifact_uuid,
     network_params,
+    dora_params,
     global_node_selectors,
 ):
     all_cl_client_info = []
@@ -76,6 +77,7 @@ def launch_dora(
         config_files_artifact_name,
         el_cl_data_files_artifact_uuid,
         network_params,
+        dora_params,
         global_node_selectors,
     )
 
@@ -86,6 +88,7 @@ def get_config(
     config_files_artifact_name,
     el_cl_data_files_artifact_uuid,
     network_params,
+    dora_params,
     node_selectors,
 ):
     config_file_path = shared_utils.path_join(
@@ -93,7 +96,9 @@ def get_config(
         DORA_CONFIG_FILENAME,
     )
 
-    if network_params.eip7594_fork_epoch < 100000000:
+    if dora_params.image != "":
+        IMAGE_NAME = dora_params.image
+    elif network_params.eip7594_fork_epoch < 100000000:
         IMAGE_NAME = "ethpandaops/dora:peer-das"
     elif network_params.electra_fork_epoch < 100000000:
         IMAGE_NAME = "ethpandaops/dora:electra-support"
@@ -111,6 +116,7 @@ def get_config(
             constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: el_cl_data_files_artifact_uuid,
         },
         cmd=["-config", config_file_path],
+        env_vars=dora_params.env,
         min_cpu=MIN_CPU,
         max_cpu=MAX_CPU,
         min_memory=MIN_MEMORY,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -797,11 +797,13 @@ def default_participant():
         "keymanager_enabled": None,
     }
 
+
 def get_default_dora_params():
     return {
         "image": "",
         "env": {},
     }
+
 
 def get_default_mev_params(mev_type, preset):
     mev_relay_image = constants.DEFAULT_FLASHBOTS_RELAY_IMAGE

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -74,6 +74,7 @@ ATTR_TO_BE_SKIPPED_AT_ROOT = (
     "network_params",
     "participants",
     "mev_params",
+    "dora_params",
     "assertoor_params",
     "goomy_blob_params",
     "tx_spammer_params",
@@ -87,6 +88,7 @@ def input_parser(plan, input_args):
     result = parse_network_params(plan, input_args)
 
     # add default eth2 input params
+    result["dora_params"] = get_default_dora_params()
     result["mev_params"] = get_default_mev_params(
         result.get("mev_type"), result["network_params"]["preset"]
     )
@@ -127,6 +129,10 @@ def input_parser(plan, input_args):
         if attr not in ATTR_TO_BE_SKIPPED_AT_ROOT and attr in input_args:
             result[attr] = value
         # custom eth2 attributes config
+        elif attr == "dora_params":
+            for sub_attr in input_args["dora_params"]:
+                sub_value = input_args["dora_params"][sub_attr]
+                result["dora_params"][sub_attr] = sub_value
         elif attr == "mev_params":
             for sub_attr in input_args["mev_params"]:
                 sub_value = input_args["mev_params"][sub_attr]
@@ -303,6 +309,10 @@ def input_parser(plan, input_args):
         )
         if result["mev_params"]
         else None,
+        dora_params=struct(
+            image=result["dora_params"]["image"],
+            env=result["dora_params"]["env"],
+        ),
         tx_spammer_params=struct(
             tx_spammer_extra_args=result["tx_spammer_params"]["tx_spammer_extra_args"],
         ),
@@ -787,6 +797,11 @@ def default_participant():
         "keymanager_enabled": None,
     }
 
+def get_default_dora_params():
+    return {
+        "image": "",
+        "env": {},
+    }
 
 def get_default_mev_params(mev_type, preset):
     mev_relay_image = constants.DEFAULT_FLASHBOTS_RELAY_IMAGE


### PR DESCRIPTION
Allow using a custom dora image and specifying custom env variables.
This is especially useful for early testnets that might need disabling some features via ENV vars 
(eg. `KILLSWITCH_DISABLE_SSZ_REQUESTS=true`, `KILLSWITCH_DISABLE_SSZ_ENCODING=true`)