### PR TITLE
feat: update Lodestar BN <> VC compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,8 +924,8 @@ snooper_enabled: true
 | Lighthouse BN | ✅            | ❌       | ✅      | ✅          | ✅
 | Prysm BN      | ✅            | ✅       | ✅      | ✅          | ✅
 | Teku BN       | ✅            | ✅       | ✅      | ✅          | ✅
-| Lodestar BN   | ✅            | ❌       | ✅      | ✅          | ❌
-| Nimbus BN     | ✅            | ❌       | ✅      | ❌          | ✅
+| Lodestar BN   | ✅            | ✅       | ✅      | ✅          | ✅
+| Nimbus BN     | ✅            | ❌       | ✅      | ✅          | ✅
 | Grandine BN   | ✅            | ✅       | ✅      | ✅          | ✅
 
 ## Custom labels for Docker and Kubernetes

--- a/README.md
+++ b/README.md
@@ -925,7 +925,7 @@ snooper_enabled: true
 | Prysm BN      | ✅            | ✅       | ✅      | ✅          | ✅
 | Teku BN       | ✅            | ✅       | ✅      | ✅          | ✅
 | Lodestar BN   | ✅            | ✅       | ✅      | ✅          | ✅
-| Nimbus BN     | ✅            | ❌       | ✅      | ✅          | ✅
+| Nimbus BN     | ✅            | ❌       | ✅      | ❌          | ✅
 | Grandine BN   | ✅            | ✅       | ✅      | ✅          | ✅
 
 ## Custom labels for Docker and Kubernetes


### PR DESCRIPTION
Lodestar works with all clients now on `unstable` branch(es). 

There is just one exception which is related to publishing blocks to Nimbus BN but that's an issue with all other VCs as well and seems to be only happening when running via kurtosis as confirmed here https://github.com/status-im/nimbus-eth2/issues/6205#issuecomment-2136878086. This issue can be solved though by forcing Lodestar to publish blocks as JSON, see https://github.com/kurtosis-tech/ethereum-package/pull/664#issuecomment-2160737709.


The kurtosis config I was using
```yaml
participants:
  # Lighthouse
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: lodestar
    cl_image: chainsafe/lodestar:next
    vc_type: lighthouse
    vc_image: sigp/lighthouse:latest
    count: 1
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: lighthouse
    cl_image: sigp/lighthouse:latest
    vc_type: lodestar
    vc_image: chainsafe/lodestar:next
    count: 1
  # Teku
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: lodestar
    cl_image: chainsafe/lodestar:next
    vc_type: teku
    vc_image: consensys/teku:latest
    count: 1
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: teku
    cl_image: consensys/teku:latest
    vc_type: lodestar
    vc_image: chainsafe/lodestar:next
    count: 1
  # Nimbus
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: lodestar
    cl_image: chainsafe/lodestar:next
    vc_type: nimbus
    vc_image: statusim/nimbus-validator-client:amd64-latest
    vc_extra_params:
      - --doppelganger-detection=off
    count: 1
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: nimbus
    cl_image: statusim/nimbus-eth2:amd64-latest
    vc_type: lodestar
    vc_image: chainsafe/lodestar:next
    vc_extra_params:
      - --http.requestWireFormat=json
    count: 1
  # Grandine
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: grandine
    cl_image: sifrai/grandine:stable
    vc_type: lodestar
    vc_image: chainsafe/lodestar:next
  # Prysm
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: lodestar
    cl_image: nflaig/lodestar:ignore-empty-statuses
    vc_type: prysm
    # vc_image: gcr.io/prysmaticlabs/prysm/validator:latest
    vc_image: ethpandaops/prysm-validator:develop-dfe31c9
    count: 1
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: prysm
    # cl_image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
    cl_image: ethpandaops/prysm-beacon-chain:develop-dfe31c9
    vc_type: lodestar
    vc_image: chainsafe/lodestar:next
    count: 1
  # Lodestar stable
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: lodestar
    cl_image: chainsafe/lodestar:next
    vc_type: lodestar
    vc_image: chainsafe/lodestar:latest
    count: 1
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: lodestar
    cl_image: chainsafe/lodestar:latest
    vc_type: lodestar
    vc_image: chainsafe/lodestar:next
    count: 1
  # Lodestar ssz
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: lodestar
    cl_image: chainsafe/lodestar:next
    vc_type: lodestar
    vc_image: chainsafe/lodestar:next
    vc_extra_params:
      - --http.requestWireFormat=ssz
    count: 1
  - el_type: geth
    el_image: ethereum/client-go:stable
    cl_type: lodestar
    cl_image: chainsafe/lodestar:next
    vc_type: lodestar
    vc_image: chainsafe/lodestar:next
    count: 1
network_params:
  genesis_delay: 120
  num_validator_keys_per_node: 64
launch_additional_services: true
additional_services:
  - assertoor
  - dora
snooper_enabled: false
disable_peer_scoring: true
assertoor_params:
  image: "ethpandaops/assertoor:master"
  run_stability_check: false
  run_block_proposal_check: false
  tests:
    - https://raw.githubusercontent.com/ethpandaops/assertoor-test/2a45f2f78dd2c336ac99bf15e61edc076f15ce67/assertoor-tests/block-proposal-check.yaml

```

